### PR TITLE
version bump: 0.1.1 -> 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "android_log-sys"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     "Nerijus Arlauskas <nercury@gmail.com>",
 ]
@@ -10,6 +10,7 @@ repository = "https://github.com/nercury/android_log-sys-rs"
 description = """
 FFI bindings to Android log Library.
 """
+documentation = "https://docs.rs/android_log-sys"
 keywords = ["ffi", "android", "log"]
 categories = ["external-ffi-bindings"]
 


### PR DESCRIPTION
According to https://github.com/semver/semver/issues/148 bump patch level after denedency change. Also add link to documentation.