### PR TITLE
Add __android_log_buf_write

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,11 @@ extern "C" {
                                tag: *const c_char,
                                text: *const c_char)
                                -> c_int;
+    pub fn __android_log_buf_write(bufID: c_int,
+                                   prio: c_int,
+                                   tag: *const c_char,
+                                   text: *const c_char)
+                                   -> c_int;
     pub fn __android_log_print(prio: c_int,
                                tag: *const c_char,
                                fmt: *const c_char,


### PR DESCRIPTION
Part of Nercury/android_logger-rs#50

Add binding to `__android_log_buf_write` to support writing log messages to a specific target buffer. The existing bindings to `__android_log_message` and `__android_log_write_log_message` could already be used to target different buffers, however this API didn't exist before API level 30. Using `__android_log_buf_write` allows us to remain compatible with apps targeting older API versions.